### PR TITLE
COC-481: remove post autoload entry from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,6 @@ __`COCKPIT_ENABLED`__: With this var, you can control if cockpit features will b
 __`COCKPIT_TOKEN`__: On this var, you should set the project token. With this, you instruct cockpit
 in which project the errors will be attached.
 
-#### Add the following lines to your _composer.json_ file:
-
-```json
-"scripts": {
-    "post-autoload-dump": [
-        "@php artisan cockpit:install --force --ansi"
-    ]
-}
-```
-
 ## Reporting unhandled exceptions
 You need to add the Cockpit as a log-channel by adding the following config to the channels section in config/logging.php:
 


### PR DESCRIPTION
## What?

- [COC-481](https://team-devsquad.atlassian.net/browse/COC-481)

## Why?

To keep the documentation up to date, we are removing unnecessary steps.

## Checklist:

#### Required to set up the environment to test this PR

- [ ] It has new migrations.
- [ ] It has one or more commands that you need to run, like seeders or custom commands.
- [ ] It has new dependencies, or dependencies, that need to be updated.
- [ ] It has new environment variables

#### Have you done all items below?

- [ ] I have made responsivity tests in different screen sizes *(only if the project must be responsive)*
- [ ] I have made corresponding changes to the .env.example file
- [ ] I have made corresponding changes to the documentation
- [ ] I ensured that all new relation id columns is a foreign key and have cascade delete/update if needed
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [X] I have merged the source branch into my current branch

## How can it be tested?

- Open the Readme file
- Check that the entry regarding the post autoload script is removed

